### PR TITLE
#6.0 error fixing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
 
     /* Bundler mode */
     "moduleResolution": "node",
-    "allowImportingTsExtensions": true,
+    // "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Solution
안녕하세요, 이러한 에러 메시지를 해결하기 위해 몇 가지 제안을 드릴 수 있겠습니다.

1. `moduleResolution` 옵션: 이 값은 'node', 'classic', 'node16', 'nodenext' 중 하나여야 합니다. 이 중 'node'가 가장 일반적입니다. `tsconfig.json` 파일의 `moduleResolution` 옵션을 아래와 같이 변경해 보세요.

```json
"moduleResolution": "node",
```

2. `allowImportingTsExtensions` 옵션: 이 옵션은 TypeScript 컴파일러 옵션 중 하나가 아닙니다. 이를 제거하거나 주석 처리하면 해결될 것입니다.

3. `resolveJsonModule` 옵션: 이 옵션은 모듈 해석 전략으로 'node'를 사용할 때만 지정할 수 있습니다. `moduleResolution`을 'node'로 변경한 후 이 옵션을 사용하면 됩니다.

위의 변경 사항을 적용한 후 다시 빌드를 시도해 보세요. 문제가 계속되면 추가 정보를 제공해 주시면 감사하겠습니다.